### PR TITLE
Remove custom `configPath` setting for engine.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "ember-cli-babel": "^5.1.6",
     "ember-data": "2.5.3",
     "ember-engines": "dgeb/ember-engines#v0.2"
-  },
-  "ember-addon": {
-    "configPath": "tests/dummy/config"
   }
 }


### PR DESCRIPTION
See https://github.com/dgeb/ember-engines/issues/149 for full 
background on why this is necessary and what alternatives are 
available.

Fixes https://github.com/dgeb/ember-engines-demo/issues/2
